### PR TITLE
Bump NGINX and Unifi versions as applicable

### DIFF
--- a/nginx/Dockerfile.template
+++ b/nginx/Dockerfile.template
@@ -4,8 +4,8 @@ FROM balenalib/%%RESIN_MACHINE_NAME%%-debian:stretch
 # Imported from https://github.com/nginxinc/docker-nginx/blob/master/mainline/stretch/Dockerfile
 #
 
-ENV NGINX_VERSION 1.15.2-1~stretch
-ENV NJS_VERSION   1.15.2.0.2.2-1~stretch
+ENV NGINX_VERSION 1.17.0-1~stretch
+ENV NJS_VERSION   1.17.0.0.3.2-1~stretch
 
 RUN set -x \
 	&& apt-get update \

--- a/unifi/Dockerfile.amd64
+++ b/unifi/Dockerfile.amd64
@@ -1,1 +1,1 @@
-FROM jacobalberty/unifi:5.10.21
+FROM jacobalberty/unifi:5.10.23


### PR DESCRIPTION
Sadly the ARM versions of the Unifi service do not have version
tagged images upstream, so hoping that the new one is pulled on repush,
instead of cache (or push with `balena push Appname --nocache`)

Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>