### PR TITLE
unms: fix logrotate

### DIFF
--- a/unms/Dockerfile.aarch64
+++ b/unms/Dockerfile.aarch64
@@ -1,1 +1,3 @@
 FROM oznu/unms:0.13.3-armhf
+
+RUN chmod 0644 /etc/logrotate.d/unms

--- a/unms/Dockerfile.amd64
+++ b/unms/Dockerfile.amd64
@@ -1,1 +1,3 @@
 FROM oznu/unms:0.13.3
+
+RUN chmod 0644 /etc/logrotate.d/unms

--- a/unms/Dockerfile.armv7
+++ b/unms/Dockerfile.armv7
@@ -1,1 +1,3 @@
 FROM oznu/unms:0.13.3-armhf
+
+RUN chmod 0644 /etc/logrotate.d/unms

--- a/unms/Dockerfile.armv7hf
+++ b/unms/Dockerfile.armv7hf
@@ -1,1 +1,3 @@
 FROM oznu/unms:0.13.3-armhf
+
+RUN chmod 0644 /etc/logrotate.d/unms


### PR DESCRIPTION
The unms logrotate file has the wrong mode, and thus not effective,
Checked manually, previously would get:

```
error: Ignoring /etc/logrotate.d/unms because of bad file mode - must be 0644 or 0444.
```

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>