### PR TITLE
unifi: bump version to 5.10.25

### DIFF
--- a/unifi/Dockerfile.amd64
+++ b/unifi/Dockerfile.amd64
@@ -1,1 +1,1 @@
-FROM jacobalberty/unifi:5.10.23
+FROM jacobalberty/unifi:5.10.25


### PR DESCRIPTION
Only amd64 as the ARM releases are reusing the same tag,
unfortunately.

Signed-off-by: Gergely Imreh <gergely@balena.io>