### PR TITLE
Bump unifi version for 5.10.26

### DIFF
--- a/unifi/Dockerfile.amd64
+++ b/unifi/Dockerfile.amd64
@@ -1,1 +1,1 @@
-FROM jacobalberty/unifi:5.10.25
+FROM jacobalberty/unifi:5.10.26


### PR DESCRIPTION
As usual, for arm devices the image has the same tag still (so no pinning possible), but content changed. At least the AMD64 image we can pin.

Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>