### PR TITLE
Move to unms container fork and update

### DIFF
--- a/unms/Dockerfile.aarch64
+++ b/unms/Dockerfile.aarch64
@@ -1,3 +1,3 @@
-FROM oznu/unms:0.13.3-armhf
+FROM nico640/docker-unms:1.0.3-armhf
 
 RUN chmod 0644 /etc/logrotate.d/unms

--- a/unms/Dockerfile.amd64
+++ b/unms/Dockerfile.amd64
@@ -1,3 +1,3 @@
-FROM oznu/unms:0.13.3
+FROM nico640/docker-unms:1.0.3
 
 RUN chmod 0644 /etc/logrotate.d/unms

--- a/unms/Dockerfile.armv7
+++ b/unms/Dockerfile.armv7
@@ -1,3 +1,3 @@
-FROM oznu/unms:0.13.3-armhf
+FROM nico640/docker-unms:1.0.3-armhf
 
 RUN chmod 0644 /etc/logrotate.d/unms

--- a/unms/Dockerfile.armv7hf
+++ b/unms/Dockerfile.armv7hf
@@ -1,3 +1,3 @@
-FROM oznu/unms:0.13.3-armhf
+FROM nico640/docker-unms:1.0.3-armhf
 
 RUN chmod 0644 /etc/logrotate.d/unms


### PR DESCRIPTION
The original repo is no longer maintained, see the announcement
at https://github.com/oznu/docker-unms/issues/53
Use the relevant fork from https://github.com/Nico640/docker-unms

Only smoke-tested so far, since I don't have hardware to check it with.